### PR TITLE
Cookie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Using it is simple as:
 | gid			| Group ID for filesystem. |
 | mode			| Mode for files/directories on the filesystem (600, 666, etc). |
 |			| Files will never have the executable bit on, directories always. |
+| cookie		| Authorization Cookie (Useful for O365 Sharepoint/OneDrive for Business) |
 | password		| Password of webdav user |
 | username		| Username of webdav user |
 | async_read		| As per fuse documentation |

--- a/main.go
+++ b/main.go
@@ -84,6 +84,8 @@ func rebuildOptions(url, path string) {
 			os.Setenv("WEBDAV_USERNAME", o[9:])
 		} else if strings.HasPrefix(o, "password=") {
 			os.Setenv("WEBDAV_PASSWORD", o[9:])
+		} else if strings.HasPrefix(o, "cookie=") {
+			os.Setenv("WEBDAV_COOKIE", o[7:])
 		} else {
 			stropts = append(stropts, o)
 		}
@@ -226,14 +228,19 @@ func main() {
 
 	username := os.Getenv("WEBDAV_USERNAME")
 	password := os.Getenv("WEBDAV_PASSWORD")
+	cookie   := os.Getenv("WEBDAV_COOKIE")
 	if mountOpts.Username != "" {
 		username = mountOpts.Username
 	}
 	if mountOpts.Password != "" {
 		password = mountOpts.Password
 	}
+	if mountOpts.Cookie != "" {
+		cookie = mountOpts.Cookie
+	}
 	os.Unsetenv("WEBDAV_USERNAME")
 	os.Unsetenv("WEBDAV_PASSWORD")
+	os.Unsetenv("WEBDAV_COOKIE")
 
 	// for some reason we can end up without a $PATH ..
 	if os.Getenv("PATH") == "" {
@@ -246,6 +253,7 @@ func main() {
 		MaxIdleConns: int(mountOpts.MaxIdleConns),
 		Username: username,
 		Password: password,
+		Cookie: cookie,
 	}
 	err = dav.Mount()
 	if err != nil {

--- a/mountoptions.go
+++ b/mountoptions.go
@@ -17,6 +17,7 @@ type MountOptions struct {
 	Uid			uint32
 	Gid			uint32
 	Mode			uint32
+	Cookie			string
 	Password		string
 	Username		string
 	AsyncRead		bool
@@ -60,6 +61,8 @@ func parseMountOptions(n string, sloppy bool) (mo MountOptions, err error) {
 			err = parseUInt32(v, 10, "gid", &mo.Gid)
 		case "mode":
 			err = parseUInt32(v, 8, "mode", &mo.Mode)
+		case "cookie":
+			mo.Cookie = v
 		case "password":
 			mo.Password = v
 		case "username":

--- a/webdav.go
+++ b/webdav.go
@@ -24,6 +24,7 @@ type DavClient struct {
 	Url		string
 	Username	string
 	Password	string
+	Cookie		string
 	Methods		map[string]bool
 	DavSupport	map[string]bool
 	IsSabre		bool
@@ -265,6 +266,9 @@ func (d *DavClient) buildRequest(method string, path string, b ...interface{}) (
 	}
 	if d.Username != "" || d.Password != "" {
 		req.SetBasicAuth(d.Username, d.Password)
+	}
+	if d.Cookie != "" {
+		req.Header.Set("Cookie", d.Cookie)
 	}
 	return
 }


### PR DESCRIPTION
This allows mounting Sharepoint 365/OneDrive for Business by copying the rtFa & FedAuth cookies from a web browser with an active session and specifying them through the new argument. These session cookies appear to stay valid for a very long time (the next day the one from the previous day should still work).
The server advertises itself as Microsoft-IIS/10.0, but I couldn't find any information about partial updates support, which means the mount will be read-only.

Maybe there are also other WebDAV services which work with a cookie as well.